### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM maven:3.8.4-openjdk-8
+COPY . /usr/src/poker-tools
+WORKDIR /usr/src/poker-tools
+
+RUN mvn install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  poker-tools:
+    build: .
+    stdin_open: true
+    tty: true
+    command: mvn spring-boot:run
+    ports:
+      - '8080:8080'


### PR DESCRIPTION
**Why/How:**

- Adding Dockerfile with Maven 3.8.4 and OpenJDK 8 
- Adding Docker-compose to handle the runtime environment exposing the spring boot Web Server running at port 8080.